### PR TITLE
fix: source eks module version to use gp2 instead of gp3

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,7 @@ resource "aws_iam_user_policy_attachment" "AmazonEKSWorkerNodePolicy" {
 
 module "eks" {
   source          = "terraform-aws-modules/eks/aws"
+  version         = "13.2.1"
   cluster_name    = var.cluster_name
   cluster_version = var.cluster_version
   subnets         = var.subnets


### PR DESCRIPTION
Use specific version of official eks module, because the new one `14.0.0` added the support for `gp3` hard disk that is not currently supported on our region.